### PR TITLE
Removal of vim from instructions and dropped double quotes

### DIFF
--- a/prerequisites.md
+++ b/prerequisites.md
@@ -78,22 +78,31 @@ on your account name in the lower left, hover over your account, then select Cop
 In the Codespace terminal execute the following commands:
 ```
 mkdir ~/.snowsql
-vi ~/.snowsql/config
+touch ~/.snowsql/config
 ```
 
-Add your account details to the create credentials file for snowsql, which are the exact same values used for the Github secrets. Copy the credentials from this file into vi. To save and exit, execute shift + ZZ in the terminal:
+Now that we've created the file, we can open it in the codespace by navigating to it:
+![image](https://user-images.githubusercontent.com/7671134/234953451-8b78db0b-d02e-44df-b00c-fb9a12754167.png)
+
+In the dialog that opens, type in the path to your config file:
+```
+/home/codespace/.snowsql/config
+```
+<img width="905" alt="image" src="https://user-images.githubusercontent.com/7671134/234953793-c7c30a0b-591b-4d99-b923-36b782ca28ff.png">
+
+
+Add your account details to the config file for snowsql, which are the exact same values used for the Github secrets, be sure to save the file.
+
 Note: we aren’t actually installing or using snowsql, just creating the credentials in the location that the snowpark_utils python file expects them to be, since we are just deploying code to Snowflake and not staging local data.
 If you have successfully completed all the steps, congratulations you are ready for the Hands on Lab! If you completed these prerequisites prior to attending the Hands on Lab, you can stop the Codespace in Github where you launched it from, or it will automatically stop after 30 mintues
 
 #### Create Snowsql Credentials File
 ```
 [connections.dev]
-accountname = myaccount
-username = myusername
-password = "mypassword"
+accountname = <myaccount>
+username = <myusername>
+password = <mypassword>
 rolename = HOL_ROLE
 warehousename = HOL_WH
 dbname = HOL_DB
 ```
-
-Note: Password will need to be escaped with double quotes if it contains special characters for example "sdfT*#092$"


### PR DESCRIPTION
New instructions for creating and writing to the snowsql config file without using vim. Also, dropped the double-quote recommendation, doesn't seem to be true anymore (actually had issues when the quotes were included)