### PR TITLE
Pin ssl & cryptography to build hashes

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -5,7 +5,8 @@ channels:
 dependencies:
   - python=3.8.15
   - snowflake-snowpark-python
-  - pyopenssl=22.0.0
+  - cryptography==39.0.1=py38h9ce1e76_0
+  - pyopenssl==23.0.0=py38h06a4308_0
   - pip
   - pip:
    # Snowflake


### PR DESCRIPTION
**Don't merge until well discussed and tested!**

This pins the versions based on Snowflake's builds.  I'm not sure we should merge this, because these builds might be system dependent.  They might break out of codespaces. 

