### PR TITLE
Update conda_env.yml

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -9,7 +9,7 @@ dependencies:
   - pip
   - pip:
    # Snowflake
-    - snowflake-cli-labs
+    - snowflake-cli-labs==0.2.9
     - streamlit
     - matplotlib
     - seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 snowflake-snowpark-python[pandas]
-snowflake-cli-labs
+snowflake-cli-labs==0.2.9


### PR DESCRIPTION
The GA version of Snow CLI has a different sub-command structure.  `snow function create` no longer exists, and it looks like they changed the config files too. 

This fix pins the version at the working beta.  We'll need to fix this issue long-term by adapting to the GA version of Snow CLI.